### PR TITLE
Fix initialization of pseudo locales

### DIFF
--- a/PropertiesFileType.js
+++ b/PropertiesFileType.js
@@ -47,7 +47,7 @@ var PropertiesFileType = function(project) {
     this.pseudos = {};
 
     // generate all the pseudo bundles we'll need
-    project.locales && project.locales.forEach(function(locale) {
+    project.settings && project.settings.locales && project.settings.locales.forEach(function(locale) {
         var pseudo = this.API.getPseudoBundle(locale, this, project);
         if (pseudo) {
             this.pseudos[locale] = pseudo;

--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 Ilib loctool plugin to parse and localize Java properties files in the traditional format.
 If you need an xml-style properties file, use ilib-loctool-properties-xml instead.
 
-# Release Notes
+## License
+
+This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+file for more details.
+
+## Release Notes
+
+### v1.0.2
+
+- Fix a bug where the pseudo locales were not initialized properly.
+  This fix gets the right set of locales from the project settings to
+  see if any of them are pseudo locales.
 
 ## v1.0.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-properties",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process ilib-loctool-properties files",
     "license": "Apache-2.0",


### PR DESCRIPTION
- Fix a bug where the pseudo locales were not initialized properly. This fix gets the right set of locales from the project settings to see if any of them are pseudo locales.